### PR TITLE
Prevent example from failing on unmerged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ on:
 jobs:
   backport:
     name: Backport PR
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ on:
 jobs:
   backport:
     name: Backport PR
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action


### PR DESCRIPTION
This should prevent users from experiencing #127 when simply following the README example.